### PR TITLE
MED-790 - Pass min/max values down to d2l-progress component

### DIFF
--- a/d2l-seek-bar.js
+++ b/d2l-seek-bar.js
@@ -136,7 +136,7 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-seek-bar">
 
 		<div id="sliderContainer" fullWidth$="[[fullWidth]]">
 			<div class="bar-container">
-				<d2l-progress id="sliderBar" value="{{immediateValue}}" on-down="_barDown" on-up="_barUp" on-track="_onTrack"></d2l-progress>
+				<d2l-progress id="sliderBar" min="{{min}}" max="{{max}}" value="{{immediateValue}}" on-down="_barDown" on-up="_barUp" on-track="_onTrack"></d2l-progress>
 			</div>
 			<div id="knobContainer">
 				<div id="sliderKnob" class="slider-knob" on-down="_knobDown" on-track="_onTrack">


### PR DESCRIPTION
fix issue where `d2l-progress` component isn't being passed min/max values. The seek bar itself works if you select non-default min/max values, but the "progress" is rendered incorrectly and doesn't align with the position of the knob.